### PR TITLE
New job commit not found

### DIFF
--- a/.github/workflows/work-allocator.yml
+++ b/.github/workflows/work-allocator.yml
@@ -27,6 +27,12 @@ jobs:
           git_commit_gpgsign: true
           fingerprint: "BD98B3F42545FF93EFF55F7F3F39AA1432CA6AD7"
 
+      - name: Set the length for git short commit hashes
+        run: |
+          # Why do we need this? https://github.com/Nautilus-Cyberneering/library-consumer/issues/22
+          # https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev
+          git config --global core.abbrev 7
+
       - name: Get next job
         id: get-next-job
         uses: Nautilus-Cyberneering/git-queue@v1-beta


### PR DESCRIPTION
The `work-allocator` workflow started failing because git's short commit length changed from 7 chars to 8. As @da2ce7 pointed out [here](https://github.com/Nautilus-Cyberneering/library-consumer/issues/22#issuecomment-1092728045) short commit length is not fixed and I assumed it was always 7 chars in the [git-queue action](https://github.com/Nautilus-Cyberneering/git-queue/blob/main/src/short-commit-hash.ts).

I want to fix the issue first in the repo and open a new issue in the git-queue project to stop using short hashes.

